### PR TITLE
fixed missing import

### DIFF
--- a/brod/zk.py
+++ b/brod/zk.py
@@ -21,6 +21,7 @@ from zc.zk import ZooKeeper, FailedConnect
 
 from brod.base import BrokerPartition, ConsumerStats, MessageSet
 from brod.base import ConnectionFailure, FetchResult, KafkaError, OffsetOutOfRange
+from brod.simple import SimpleConsumer
 from brod.blocking import Kafka
 
 log = logging.getLogger('brod.zk')


### PR DESCRIPTION
The zookeeper consumer has a method that returns a simpleconsumer but that wasn't imported so it would fail. I've patched it here. 
