### PR TITLE
Support fetching higher sizes until a message is returned.

### DIFF
--- a/brod/base.py
+++ b/brod/base.py
@@ -286,8 +286,9 @@ class BaseKafka(object):
         # Send the request
         return self._write(request, callback)
     
-    def fetch(self, topic, offset, partition=None, min_size=None, max_size=None,
-              fetch_step=None, callback=None, include_corrupt=False):
+    def fetch(self, topic, offset, partition=None, max_size=None,
+              callback=None, include_corrupt=False, min_size=None,
+              fetch_step=None):
         """ Fetch messages from a kafka queue
             
             This will sequentially read and return all available messages 
@@ -297,11 +298,11 @@ class BaseKafka(object):
                 topic:      kafka topic to read from
                 offset:     offset of the first message requested
                 partition:  topic partition to read from (optional)
+                max_size:   maximum size to read from the queue,
+                            in bytes (optional)
                 min_size:   minimum size to read from the queue. if min_size and
                             fetch_step are defined, then we'll fetch sizes from
                             min_size to max_size until we have a result.
-                max_size:   maximum size to read from the queue,
-                            in bytes (optional)
                 fetch_step: the step increase for each fetch to the queue. only
                             applies if both a min_size and max_size are set.
 

--- a/brod/simple.py
+++ b/brod/simple.py
@@ -88,7 +88,7 @@ class SimpleConsumer(object):
         ZKConsumer."""
         pass
 
-    def fetch(self, min_size=None, max_size=None, fetch_step=None):
+    def fetch(self, max_size=None, min_size=None, fetch_step=None):
         log.debug("Fetch called on SimpleConsumer {0}".format(self.id))
         bps_to_offsets = self._bps_to_next_offsets
         

--- a/brod/simple.py
+++ b/brod/simple.py
@@ -88,7 +88,7 @@ class SimpleConsumer(object):
         ZKConsumer."""
         pass
 
-    def fetch(self, max_size=None):
+    def fetch(self, min_size=None, max_size=None, fetch_step=None):
         log.debug("Fetch called on SimpleConsumer {0}".format(self.id))
         bps_to_offsets = self._bps_to_next_offsets
         
@@ -103,7 +103,9 @@ class SimpleConsumer(object):
             offsets_msgs = kafka.fetch(bp.topic, 
                                        offset,
                                        partition=bp.partition,
-                                       max_size=max_size)
+                                       min_size=min_size,
+                                       max_size=max_size,
+                                       fetch_step=fetch_step)
 
             msg_set = MessageSet(bp, offset, offsets_msgs)
 
@@ -137,10 +139,13 @@ class SimpleConsumer(object):
              start_offsets=None,
              end_offsets=None,
              poll_interval=1,
+             min_size=None,
              max_size=None,
+             fetch_step=None,
              retry_limit=3):
         while self._bps_to_next_offsets:
-            for msg_set in self.fetch(max_size=max_size):
+            for msg_set in self.fetch(min_size=min_size, max_size=max_size,
+                                      fetch_step=fetch_step):
                 yield msg_set
             time.sleep(poll_interval)
     


### PR DESCRIPTION
If `max_size`, `min_size` and `fetch_step` are all given, then the Kafka
fetch will start at the minimum and fetch an increasing amount up to the
max until a message is fetched or the max is reached. The client still
will have to confirm on their end that a message is returned.

Supports `consumer.poll` and `consumer.fetch`.
